### PR TITLE
[WEBSITE-1781][WEBSITE-1784] Update Varnish router

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -22,27 +22,115 @@ backend things {
 }
 
 sub vcl_recv {
-    if(req.url == "/" || req.url ~ "^/resource" || req.url ~ "^/mps" || req.url ~ "^/meta" || req.url ~ "^/search" || req.url ~ "^/postcodes" || req.url ~ "^/cookie_policy") {
-        set req.backend_hint = utilities;
-    } else if(req.url ~ "(people|constituencies|parties|parliaments|media|houses|contact_points)/\w{8}$") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "(people|constituencies|parties|parliaments|media|houses|contact_points)/\w{8}(.xml|.json)$") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "^/constituencies/postcode_lookup" || req.url ~ "^/people/postcode_lookup") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "^/constituencies/postcode_lookup(.xml|.json)" || req.url ~ "^/people/postcode_lookup(.xml|.json)") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "(parliaments)/\w{8}/(previous|next)$" || req.url ~ "(parliaments/(current|next|previous))$") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "(parliaments)/\w{8}/(previous(.json|.xml)|next(.json|.xml))$" || req.url ~ "(parliaments/(current(.json|.xml)|next(.json|.xml)|previous(.json|.xml)))$") {
-        set req.backend_hint = things;
-    } else if(req.url ~ "(contituencies/map)$" || req.url ~ "(constituencies)/\w{8}/(map)$" || req.url ~ "(constituencies/current/map)$"){
-        set req.backend_hint = things;
-    } else if(req.url ~ "(contituencies/map(.json|.xml))$" || req.url ~ "(constituencies)/\w{8}/(map(.json|.xml))$" || req.url ~ "(constituencies/current/map(.json|.xml))$"){
-        set req.backend_hint = things;
-    } else if(req.url ~ "(.ico|.jpeg|.gif|.svg|.jpg|.png|.css|.js)$") {
-        set req.backend_hint = utilities;
-    } else {
-        set req.backend_hint = lists;
-    }
+  if(req.url == "/" || req.url ~ "^/resource" || req.url ~ "^/mps" || req.url ~ "^/meta" || req.url ~ "^/search" || req.url ~ "^/postcodes" || req.url ~ "^/cookie_policy" || req.url ~ "^/find-your-constituency" || req.url ~ "^/who-should-i-contact-with-my-issue") {
+    set req.backend_hint = utilities;
+  } else if(req.url == "^/people/a-z") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/people/members") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/people/current") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/parties/a-z") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/constituencies/current/a-z/*") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/constituencies/a-z") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/constituencies/current") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/houses/*/members/current/a-z/*") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/houses/*/parties/current") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/houses/*/parties/*/*") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parties/*/*$") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parliaments/*/members") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parliaments/*/houses") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parliaments/*/houses/*/parties") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parliaments/*/parties") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/parliaments/*/constituencies") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/media") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/places") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/places/regions") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/places/*/constituencies") {
+    set req.backend_hint = lists;
+  } else if(req.url == "^/people/lookup") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/people/postcode_lookup") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/parties/lookup") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/constituencies/lookup") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/constituencies/postcode_lookup") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/constituencies/*/map") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/houses/lookup") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/houses/*/parties/*") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/parliaments/current") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/parliaments/lookup") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/parliaments/previous") {
+    set req.backend_hint = things;
+  } else if(req.url == "^/parliaments/next") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/next") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/previous") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/houses/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "/people/*/*$") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "/parties/*/*$") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "/constituencies/*/*$") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "^/houses/*/*") {
+    set req.backend_hint = lists;
+  } else if(req.url ~ "/parliaments/*/*$") {
+    set req.backend_hint = lists;
+  # Explicit use of 8 character wildcard for people, parties, constituenices and parliaments
+  # differs from ALB rules, as Varnish regex execution differs from ALB
+  } else if(req.url ~ "/people/\w{8}$") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "/parties/\w{8}$") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/postcodes/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "/constituencies/\w{8}$") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/contact-points/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/houses/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/houses/*/parties/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/houses/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/parliaments/*/parties/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "/parliaments/\w{8}$") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/media/*") {
+    set req.backend_hint = things;
+  } else if(req.url ~ "^/places/*") {
+    set req.backend_hint = things;
+  } else {
+    set req.backend_hint = lists;
+  }
 }


### PR DESCRIPTION
* Updated varnish router to include routes for 'who-should-contact-with-my-issue' and all new places + regions routes
* Changed rules of varnish router to mirror ALB rules
* Adjusted rules for people, parties, constituencies and parliaments to use 8 character wildcard rather than less explicit wildcard ('*'), because Varnish regex is executed differently from ALB