### PR TITLE
Use the 404 pages consistently for health checks.

### DIFF
--- a/scripts/vclbuilder/vcl.py
+++ b/scripts/vclbuilder/vcl.py
@@ -15,9 +15,9 @@ backend {0} {{
 """
 
 probe_urls = {
-    "lists": "/",
-    "things": "/",
-    "utilities": "/robots.txt",
+    "lists": "/404.html",
+    "things": "/404.html",
+    "utilities": "/404.html",
     "bandiera": None
 }
 


### PR DESCRIPTION
404 pages generate a 200 OK response when requested statically.