### PR TITLE
Add a pipeline as code for web1live

### DIFF
--- a/gocd/web1live.yaml
+++ b/gocd/web1live.yaml
@@ -1,0 +1,48 @@
+pipelines:
+  parliament.uk-routing:
+    group: main
+    label_template: "${COUNT}"
+    environment_variables:
+      ASSET_LOCATION_URL: https://s3-eu-west-1.amazonaws.com/web1live.pugin-website
+      STATIC_ASSET_LOCATION_URL: https://s3-eu-west-1.amazonaws.com/web1live.static-assets
+      RACK_ENV: production
+    materials:
+      parliament.uk-routing-git:
+        git: https://github.com/ukparliament/parliament.uk-routing.git
+        branch: development
+        auto_update: true
+    stages:
+      - build:
+          approval: manual
+          jobs:
+            build:
+              tasks:
+                - exec:
+                    run_if: passed
+                    command: make
+                    arguments:
+                      - build
+                - exec:
+                    run_if: passed
+                    command: make
+                    arguments:
+                      - push
+                - exec:
+                    run_if: any
+                    command: make
+                    arguments:
+                      - rmi
+      - deploy:
+          jobs:
+            build:
+              tasks:
+                - exec:
+                    run_if: passed
+                    command: make
+                    arguments:
+                      - deploy-ecs
+
+environments:
+  Web.LIVE:
+    pipelines:
+      - parliament.uk-routing


### PR DESCRIPTION
This is almost exactly the same as what we have for web1devci, except that I've set it up for manual approval for the tag release process.