### PR TITLE
Fix for the pipeline as code.

### DIFF
--- a/gocd/web1live.yaml
+++ b/gocd/web1live.yaml
@@ -1,6 +1,6 @@
 pipelines:
   parliament.uk-routing:
-    group: main
+    group: Main
     label_template: "${COUNT}"
     environment_variables:
       ASSET_LOCATION_URL: https://s3-eu-west-1.amazonaws.com/web1live.pugin-website


### PR DESCRIPTION
It seems that group names in Go.CD are case sensitive except when they
aren't. Two group names in different pipelines that differ only by case
cause a "group already exists" error to be thrown.