### PR TITLE
Allow services to be deployed to multiple clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ GO_PIPELINE_COUNTER ?= unknown
 VERSION = 0.1.$(GO_PIPELINE_COUNTER)
 
 # ECS related variables used to build our image name
-ECS_CLUSTER = ecs
+# Cluster: list all clusters to update, separated by semicolons
+ECS_CLUSTER ?= ecs;ecs_green
 AWS_REGION = eu-west-1
 
 # Tenable.io
@@ -81,4 +82,4 @@ rmi: # Remove local versions of our images.
 
 deploy-ecs: # Deploy our new Docker image onto an AWS cluster (Run in GoCD to deploy to various environments).
 	./aws_ecs/register-task-definition.sh $(APP_NAME)
-	aws ecs update-service --service $(APP_NAME) --cluster $(ECS_CLUSTER) --region $(AWS_REGION) --task-definition $(APP_NAME)
+	./aws_ecs/update-services.sh "$(ECS_CLUSTER)" "$(APP_NAME)" "$(AWS_REGION)"

--- a/aws_ecs/update-services.sh
+++ b/aws_ecs/update-services.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+ECS_CLUSTERS="$1"
+APP_NAME="$2"
+AWS_REGION="$3"
+IFS=';' read -ra C <<< "$ECS_CLUSTERS"
+for cluster in "${C[@]}"; do
+    aws ecs update-service --service $(APP_NAME) --cluster $(ECS_CLUSTER) --region $(AWS_REGION) --task-definition $(APP_NAME)
+    echo "Updated service in cluster: $cluster"
+done


### PR DESCRIPTION
Clusters are set to `ecs` and `ecs_green` by default (this is what we have set up in pdswebops). It can be overridden in individual environments by creating an environment variable `ECS_CLUSTER` in Go.CD. I have configured this to `ECS` in both web1devci and web1live GoCDs.

If this PR is successful, additional PRs will be submitted for web1devci and web1live