### PR TITLE
Don't try to deploy a service to a cluster where it doesn't exist

### DIFF
--- a/aws_ecs/update-services.sh
+++ b/aws_ecs/update-services.sh
@@ -7,6 +7,8 @@ APP_NAME="$2"
 AWS_REGION="$3"
 IFS=';' read -ra C <<< "$ECS_CLUSTERS"
 for cluster in "${C[@]}"; do
-    aws ecs update-service --service $APP_NAME --cluster $cluster --region $AWS_REGION --task-definition $APP_NAME
-    echo "Updated service in cluster: $cluster"
+    if aws ecs list-services --cluster $cluster --output text | grep $APP_NAME > /dev/null; then
+        aws ecs update-service --service $APP_NAME --cluster $cluster --region $AWS_REGION --task-definition $APP_NAME
+        echo "Updated service in cluster: $cluster"
+    fi
 done


### PR DESCRIPTION
We need this because not all clusters will contain the routing service.
(ecs_green does; ecs does not). We don't want the build to fail in this
case.