### PR TITLE
Don't use ALBs for now.

### DIFF
--- a/scripts/build-vcl.py
+++ b/scripts/build-vcl.py
@@ -7,7 +7,7 @@ import sys
 import urllib.request
 
 # Set this to False if you want to use Varnish for load balancing
-USE_ALBS = True
+USE_ALBS = False
 
 def get_cluster_name():
     # Get the IP address of the container


### PR DESCRIPTION
ALBs have multiple IP addresses mapped to their domain names and Varnish
doesn't like this. We need to find out how to handle this before we can
proceed.