### PR TITLE
Resolve the DNS entries for the ALBs.

### DIFF
--- a/scripts/build-vcl.py
+++ b/scripts/build-vcl.py
@@ -7,7 +7,7 @@ import sys
 import urllib.request
 
 # Set this to False if you want to use Varnish for load balancing
-USE_ALBS = False
+USE_ALBS = True
 
 def get_cluster_name():
     # Get the IP address of the container


### PR DESCRIPTION
We need to do this because Varnish can only accept one IP address per backend; ALBs have one IP address per availability zone.

Generating the VCL on the fly, rather than using a DNS director (which is deprecated as of Varnish 4.0) is the recommended way to do this. See https://info.varnish-software.com/blog/varnish-backends-in-the-cloud